### PR TITLE
Use first config file found.

### DIFF
--- a/netfilter_openvpn.py
+++ b/netfilter_openvpn.py
@@ -60,6 +60,9 @@ for cfg in cfg_path:
 		config = imp.load_source('config', cfg)
 	except:
 		pass
+	else:
+		# use first config file found
+		break
 
 if config == None:
 	print("Failed to load config")


### PR DESCRIPTION
Looking at the code it seems like the first found config file should be used.
But instead the code loops through the possible files imports them and continues with the next.
We should stop, if we found a file.
