### PR TITLE
Fix chain for block rule

### DIFF
--- a/netfilter_openvpn.py
+++ b/netfilter_openvpn.py
@@ -340,7 +340,7 @@ def kill_block_hack(usersrcip, usercn):
 		This function allows traffic through.
 	"""
 	try:
-		iptables('-D INPUT -s ' + usersrcip + ' -j DROP')
+		iptables('-D FORWARD -s ' + usersrcip + ' -j DROP')
 	except:
 		mdmsg.send(summary='Failed to delete blocking rule, potential security issue', severity='CRITICAL',
 		details={'vpnip': usersrcip, 'user': usercn})

--- a/netfilter_openvpn.sh
+++ b/netfilter_openvpn.sh
@@ -12,9 +12,9 @@ SUDO=/usr/bin/sudo
 IPTABLES=/sbin/iptables
 
 if [[ ${operation} == "delete" ]]; then
-	${SUDO} ${IPTABLES} -D INPUT -s ${address} -j DROP
+	${SUDO} ${IPTABLES} -D FORWARD -s ${address} -j DROP
 else
-	${SUDO} ${IPTABLES} -I INPUT -s ${address} -j DROP || {
+	${SUDO} ${IPTABLES} -I FORWARD -s ${address} -j DROP || {
 		echo "Failed to run initial iptables command"
 		exit 127
 	}


### PR DESCRIPTION
At least here the drop rule in the INPUT chain doesn't block any
traffic.
Could be because OpenVPN doesn't "create" the packets, but injects them
into the tun adapter. So it's like forwarding packets for the network
stack. Packets from tun interface are forwarded to the external
interface (eth0, or whatever).
