### PR TITLE
Add systemd unit file to make shutdowns be graceful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ INSTALL	:= install
 DESTDIR	:= /
 PREFIX	:= /usr
 PACKAGE := openvpn-netfilter
-VERSION := 1.0.0
+VERSION := 1.0.1
 
 all:
 	./setup.py build
@@ -24,6 +24,7 @@ pypi:
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/lib/openvpn/plugins
 	mkdir -p $(DESTDIR)/etc/openvpn
+	mkdir -p $(DESTDIR)/etc/systemd/system/openvpn@.service.d
 	mkdir -p $(DESTDIR)/etc/sudoers.d
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -m755 netfilter_openvpn.py $(DESTDIR)$(PREFIX)/lib/openvpn/plugins
@@ -32,6 +33,7 @@ install:
 	$(INSTALL) -m755 scripts/vpn-fw-find-user.sh $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -m755 scripts/vpn-netfilter-cleanup-ip.sh $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -m440 sudoers.inc $(DESTDIR)/etc/sudoers.d/openvpn-netfilter
+	$(INSTALL) -m644 systemd-only-kill-process.conf $(DESTDIR)/etc/systemd/system/openvpn@.service.d/only-kill-process.conf
 
 clean:
 	rm -f *.o

--- a/openvpn-netfilter.spec
+++ b/openvpn-netfilter.spec
@@ -2,8 +2,8 @@
 %define prefix  /usr
 
 Name:           openvpn-netfilter
-Version:        1.0
-Release:        2%{?dist}
+Version:        1.0.1
+Release:        1%{?dist}
 Packager:       Greg Cox <gcox@mozilla.com>
 Summary:        OpenVPN netfilter plugin
 
@@ -50,8 +50,21 @@ make install DESTDIR=%{buildroot}
 %{prefix}/lib/openvpn/plugins/netfilter_openvpn.py
 %{prefix}/lib/openvpn/plugins/netfilter_openvpn.pyc
 %exclude %{prefix}/lib/openvpn/plugins/netfilter_openvpn.pyo
+%if %{rhel} >=7
+%attr(0644,root,root)/etc/systemd/system/openvpn@.service.d/only-kill-process.conf
+%else
+%exclude /etc/systemd/system/openvpn@.service.d/only-kill-process.conf
+%endif
 %attr(0440,root,root)/etc/sudoers.d/openvpn-netfilter
 %attr(0640,root,openvpn) %config(noreplace) %verify(not md5 size mtime)/etc/netfilter_openvpn.conf
+
+%if %{rhel} >=7
+%post
+    systemctl daemon-reload >/dev/null 2>&1
+
+%postun
+    systemctl daemon-reload >/dev/null 2>&1
+%endif
 
 %files utils
 %defattr(0755,root,root)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 setup(
     name = "openvpn-netfilter",
         py_modules = ['netfilter_openvpn'],
-        version = "1.0.0",
+        version = "1.0.1",
         author = "Guillaume Destuynder",
         author_email = "gdestuynder@mozilla.com",
         description = ("A plugin to OpenVPN to use netfilter/iptables rules per connected user"),

--- a/systemd-only-kill-process.conf
+++ b/systemd-only-kill-process.conf
@@ -1,0 +1,14 @@
+[Service]
+#
+# netfilter_openvpn.sh forks off netfilter_openvpn.py in order to delete
+# iptables/ipset rules as the process shuts down.  systemd.kill(5) in its
+# default KillMode=control-group will kill those forks before they have a
+# chance to do their work.  Rather than un-fork them and potentially create
+# runtime issues, we pay the penalty at shutdown time.
+#
+# There is a slight risk that you could blow out TimeoutStopSec from
+# systemd.service(5), but the CentOS default is around 90s.  If you exceed
+# that, you may leave iptables orphans, but you probably have bigger
+# issues on the server at that point.
+#
+KillMode=process


### PR DESCRIPTION
Discovered-the-hard-way that systemd's KillMode of 'control-group' was killing off the forked iptables/ipset cleanup processes before they could complete.  Notes are in the systemd unit file to explain 'why' to future archaeologists.